### PR TITLE
BDC digital, ajout du choix de l'organisme de financement

### DIFF
--- a/models/ADV_BDC_infoPaiements.js
+++ b/models/ADV_BDC_infoPaiements.js
@@ -76,6 +76,20 @@ module.exports = (sequelize, DataTypes) => {
                 allowNull : false,
                 defaultValue : false
             },
+            organismeCredit : {
+                type : DataTypes.ENUM('Sofinco', 'domofinance'),
+                allowNull : true,
+                defaultValue : null,
+                validate : {
+                    isIn : {
+                        args : [['Sofinco','domofinance']],
+                        msg : "L'organisme de crédit doit être sélectionné dans la liste fournie."
+                    },
+                    isCredit : function(value) {
+                        if(value !== null && !!this.getDataValue('isCredit') === false) throw new Error(`Pour remplir l'organisme de crédit, 'Paiement via un organisme de crédit' doit être coché.`)
+                    }
+                }
+            },
             montantCredit : {
                 type : DataTypes.DECIMAL(10,2),
                 allowNull : false,
@@ -92,7 +106,7 @@ module.exports = (sequelize, DataTypes) => {
                         if(!isSet(value) && !!this.getDataValue('isCredit')) throw new Error("Le montant du crédit doit être renseigné.")
                     },                    
                 }
-            },
+            },            
             nbMensualiteCredit : {
                 type : DataTypes.INTEGER,
                 allowNull : false,

--- a/public/assets/css/adv/bdc_recapitulatif.css
+++ b/public/assets/css/adv/bdc_recapitulatif.css
@@ -464,3 +464,8 @@ position: absolute;
 .infos{
     font-size: 10px;
 }
+
+.organismeCredit {
+    text-decoration: underline;
+    font-weight: 600;
+}

--- a/public/assets/css/pdf/BDC_V-LAM.css
+++ b/public/assets/css/pdf/BDC_V-LAM.css
@@ -481,3 +481,8 @@ position: absolute;
 .infos{
     font-size: 10px;
 }
+
+.organismeCredit {
+    text-decoration: underline;
+    font-weight: 600;
+}

--- a/public/assets/js/adv/bdc_creation.js
+++ b/public/assets/js/adv/bdc_creation.js
@@ -46,7 +46,13 @@ async function initDocument() {
         document.getElementById('isCredit').onclick = toggleDivsPaiement
 
         document.querySelectorAll('.btnCarouselPrev').forEach(btn => {
-            btn.onclick = () => $('#carouselBDC').carousel('prev')
+            btn.onclick = () => {
+                // retrait du css récaputilatif si retour en arrière et qu'il a été chargé
+                const link = document.querySelector('link[href="/public/assets/css/adv/bdc_recapitulatif.css"]')
+                if(link) link.parentNode.removeChild(link)
+
+                return $('#carouselBDC').carousel('prev')
+            }
         })
         document.getElementById('validationClients').onclick = validationClients
         document.getElementById('validationCommande').onclick = validationCommande
@@ -718,6 +724,7 @@ async function validationPaiement() {
                 isComptant : document.getElementById('isComptant').checked,
                 montantComptant : document.getElementById('montantComptant').value,
                 isCredit : document.getElementById('isCredit').checked,
+                organismeCredit : document.getElementById('organismeCredit').value,
                 montantCredit : document.getElementById('montantCredit').value,
                 nbMensualiteCredit : document.getElementById('nbMensualiteCredit').value,
                 montantMensualiteCredit : document.getElementById('montantMensualiteCredit').value,

--- a/public/pdf/BDC_V-LAM.ejs
+++ b/public/pdf/BDC_V-LAM.ejs
@@ -220,7 +220,7 @@
                 <label>euros</label>
             </div>
             <div class="row ligne ligne11">
-                <div class="<%= infosPaiement.isCredit ? 'selectedBox' : 'box' %>">Paiement via un organisme de crédit pour un montant de</div>
+                <div class="<%= infosPaiement.isCredit ? 'selectedBox' : 'box' %>"><%- infosPaiement.organismeCredit ? `Paiement via l'organisme de crédit <span class="organismeCredit">${infosPaiement.organismeCredit}</span> pour un montant de` : 'Paiement via un organisme de crédit pour un montant de' %></div>
                 <p class="emplacement"><%= infosPaiement.isCredit ? infosPaiement.montantCredit : '' %></p>
                 <label>euros</label>
                 <label>Nombre de mensualités</label>

--- a/public/views/ADV/bdc_creation.ejs
+++ b/public/views/ADV/bdc_creation.ejs
@@ -396,6 +396,20 @@
                                 </div>
                                 <div class="col-sm-12" id="divContentCredit" style="display: none;">
                                     <div class="row">
+                                        <div class="col-sm-12">
+                                            <div class="row">
+                                                <div class="col-md-6">
+                                                    <div class="row phraseRow">
+                                                        <label for="organismeCredit">Organisme délivrant le crédit</label>
+                                                        <select id="organismeCredit">
+                                                            <option value="undefined">Non renseigné</option>
+                                                            <option value="Sofinco">Sofinco</option>
+                                                            <option value="domofinance">domofinance</option>
+                                                        </select>
+                                                    </div>  
+                                                </div>
+                                            </div>                                            
+                                        </div>
                                         <div class="col-md-6">
                                             <div class="row phraseRow">
                                                 <label for="montantCredit">Paiement via un organisme de crédit pour un montant de</label>

--- a/public/views/partials/ADV/bdc_recapitulatif_V-LAM.ejs
+++ b/public/views/partials/ADV/bdc_recapitulatif_V-LAM.ejs
@@ -190,7 +190,7 @@
                 <label>euros</label>
             </div>
             <div class="row ligne ligne11">
-                <div class="<%= infosPaiement.isCredit ? 'selectedBox' : 'box' %>">Paiement via un organisme de crédit pour un montant de</div>
+                <div class="<%= infosPaiement.isCredit ? 'selectedBox' : 'box' %>"><%= infosPaiement.organismeCredit ? `Paiement via l'organisme de crédit <span class="organismeCredit">${infosPaiement.organismeCredit}</span> pour un montant de` : 'Paiement via un organisme de crédit pour un montant de' %></div>
                 <p class="emplacement"><%= infosPaiement.isCredit ? infosPaiement.montantCredit : '' %></p>
                 <label>euros</label>
                 <label>Nombre de mensualités</label>

--- a/routes/ADV/bdc_infoPaiements.js
+++ b/routes/ADV/bdc_infoPaiements.js
@@ -67,6 +67,8 @@ function checkInfosPaiementSent({ infosPaiement, prixTTC }) {
     // vérification du crédit
     if(isSet(infosPaiement.isCredit) && !!infosPaiement.isCredit) {
         infosPaiement.isCredit = !!infosPaiement.isCredit
+        if(isSet(infosPaiement.organismeCredit) && !['Sofinco','domofinance'].includes(infosPaiement.organismeCredit)) throw "L'organisme de crédit doit être sélectionné dans la liste fournie."
+        infosPaiement.organismeCredit = isSet(infosPaiement.organismeCredit) ? infosPaiement.organismeCredit : null
         infosPaiement.montantCredit = validations.validationPositiveNumbers(infosPaiement.montantCredit, "Le montant du crédit")
         infosPaiement.nbMensualiteCredit = validations.validationPositiveInteger(infosPaiement.nbMensualiteCredit, "Le nombre de mensualités du crédit")
         infosPaiement.montantMensualiteCredit = validations.validationPositiveNumbers(infosPaiement.montantMensualiteCredit, "Le montant des mensualités du crédit")


### PR DESCRIPTION
modifications pour ajout du choix de l'organisme de crédit ainsi que de son affichage. En BDD pour ADV_BDC_infosPaiement la colonne organismeCredit a été ajoutée avec enum('Sofinco', 'domofinance') default NULL